### PR TITLE
make API documentation visible by default when using custom theory code

### DIFF
--- a/samples/CustomUISample.js
+++ b/samples/CustomUISample.js
@@ -1,8 +1,8 @@
-import { Popup } from "../api/ui/Popup";
-import { Color } from "../api/ui/properties/Color";
-import { ImageSource } from "../api/ui/properties/ImageSource";
-import { Thickness } from "../api/ui/properties/Thickness";
-import { ui } from "../api/ui/UI"
+import { Popup } from "./api/ui/Popup";
+import { Color } from "./api/ui/properties/Color";
+import { ImageSource } from "./api/ui/properties/ImageSource";
+import { Thickness } from "./api/ui/properties/Thickness";
+import { ui } from "./api/ui/UI"
 
 var id = "custom_ui_id";
 var name = "Custom UI";

--- a/samples/T1-RecurenceRelation.js
+++ b/samples/T1-RecurenceRelation.js
@@ -1,8 +1,8 @@
-﻿import { ExponentialCost, FirstFreeCost, LinearCost } from "../api/Costs";
-import { Localization } from "../api/Localization";
-import { parseBigNumber, BigNumber } from "../api/BigNumber";
-import { theory } from "../api/Theory";
-import { Utils } from "../api/Utils";
+﻿import { ExponentialCost, FirstFreeCost, LinearCost } from "./api/Costs";
+import { Localization } from "./api/Localization";
+import { parseBigNumber, BigNumber } from "./api/BigNumber";
+import { theory } from "./api/Theory";
+import { Utils } from "./api/Utils";
 
 var id = "recurrence_relation";
 var name = "Recurrence Relation";

--- a/samples/T2-DifferentialCalculus.js
+++ b/samples/T2-DifferentialCalculus.js
@@ -1,8 +1,8 @@
-import { ExponentialCost, FirstFreeCost } from "../api/Costs";
-import { Localization } from "../api/Localization";
-import { parseBigNumber, BigNumber } from "../api/BigNumber";
-import { theory } from "../api/Theory";
-import { Utils } from "../api/Utils";
+import { ExponentialCost, FirstFreeCost } from "./api/Costs";
+import { Localization } from "./api/Localization";
+import { parseBigNumber, BigNumber } from "./api/BigNumber";
+import { theory } from "./api/Theory";
+import { Utils } from "./api/Utils";
 
 var id = "differential_calculus"
 var name = "Differential Calculus";

--- a/samples/T3-LinearAlgebra.js
+++ b/samples/T3-LinearAlgebra.js
@@ -1,8 +1,8 @@
-import { ExponentialCost, FirstFreeCost } from "../api/Costs";
-import { Localization } from "../api/Localization";
-import { parseBigNumber, BigNumber } from "../api/BigNumber";
-import { theory } from "../api/Theory";
-import { Utils } from "../api/Utils";
+import { ExponentialCost, FirstFreeCost } from "./api/Costs";
+import { Localization } from "./api/Localization";
+import { parseBigNumber, BigNumber } from "./api/BigNumber";
+import { theory } from "./api/Theory";
+import { Utils } from "./api/Utils";
 
 var id = "linear_algebra"
 var name = "Linear Algebra";

--- a/samples/T4-Polynomials.js
+++ b/samples/T4-Polynomials.js
@@ -1,14 +1,14 @@
-import { ExponentialCost, FirstFreeCost } from "../api/Costs";
-import { Localization } from "../api/Localization";
-import { parseBigNumber, BigNumber } from "../api/BigNumber";
-import { theory } from "../api/Theory";
-import { Utils } from "../api/Utils";
+import { ExponentialCost, FirstFreeCost } from "./api/Costs";
+import { Localization } from "./api/Localization";
+import { parseBigNumber, BigNumber } from "./api/BigNumber";
+import { theory } from "./api/Theory";
+import { Utils } from "./api/Utils";
 
 var id = "polynomials"
 var name = "Polynomials";
 var description = "A implementation of the 'Polynomials' theory from the game.";
 var authors = "Gilles-Philippe Paillé";
-var version = 1;
+var version = 2;
 
 var q = BigNumber.ZERO;
 var q1, q2;

--- a/samples/T5-LogisticFunction.js
+++ b/samples/T5-LogisticFunction.js
@@ -1,8 +1,8 @@
-import { ExponentialCost, FirstFreeCost } from "../api/Costs";
-import { Localization } from "../api/Localization";
-import { parseBigNumber, BigNumber } from "../api/BigNumber";
-import { theory } from "../api/Theory";
-import { Utils } from "../api/Utils";
+import { ExponentialCost, FirstFreeCost } from "./api/Costs";
+import { Localization } from "./api/Localization";
+import { parseBigNumber, BigNumber } from "./api/BigNumber";
+import { theory } from "./api/Theory";
+import { Utils } from "./api/Utils";
 
 var id = "logistic_function"
 var name = "Logistic Function";

--- a/samples/T6-IntegralCalculus.js
+++ b/samples/T6-IntegralCalculus.js
@@ -1,8 +1,8 @@
-import { ExponentialCost, FirstFreeCost } from "../api/Costs";
-import { Localization } from "../api/Localization";
-import { parseBigNumber, BigNumber } from "../api/BigNumber";
-import { theory } from "../api/Theory";
-import { Utils } from "../api/Utils";
+import { ExponentialCost, FirstFreeCost } from "./api/Costs";
+import { Localization } from "./api/Localization";
+import { parseBigNumber, BigNumber } from "./api/BigNumber";
+import { theory } from "./api/Theory";
+import { Utils } from "./api/Utils";
 
 var id = "integral_calculus"
 var name = "Integral Calculus";

--- a/samples/T7-NumericalMethods.js
+++ b/samples/T7-NumericalMethods.js
@@ -1,8 +1,8 @@
-import { ExponentialCost, FirstFreeCost } from "../api/Costs";
-import { Localization } from "../api/Localization";
-import { parseBigNumber, BigNumber } from "../api/BigNumber";
-import { theory } from "../api/Theory";
-import { Utils } from "../api/Utils";
+import { ExponentialCost, FirstFreeCost } from "./api/Costs";
+import { Localization } from "./api/Localization";
+import { parseBigNumber, BigNumber } from "./api/BigNumber";
+import { theory } from "./api/Theory";
+import { Utils } from "./api/Utils";
 
 var id = "numerical_methods"
 var name = "Numerical Methods";

--- a/samples/T8-ChaosTheory.js
+++ b/samples/T8-ChaosTheory.js
@@ -1,8 +1,8 @@
-import { ExponentialCost, FirstFreeCost } from "../api/Costs";
-import { Localization } from "../api/Localization";
-import { BigNumber } from "../api/BigNumber";
-import { theory } from "../api/Theory";
-import { Utils } from "../api/Utils";
+import { ExponentialCost, FirstFreeCost } from "./api/Costs";
+import { Localization } from "./api/Localization";
+import { BigNumber } from "./api/BigNumber";
+import { theory } from "./api/Theory";
+import { Utils } from "./api/Utils";
 
 var id = "chaos_theory"
 var name = "Chaos Theory";

--- a/samples/T9-ConvergenceTest.js
+++ b/samples/T9-ConvergenceTest.js
@@ -1,8 +1,8 @@
-import { ExponentialCost, FirstFreeCost, LinearCost } from "../api/Costs";
-import { Localization } from "../api/Localization";
-import { BigNumber, parseBigNumber } from "../api/BigNumber";
-import { theory } from "../api/Theory";
-import { Utils } from "../api/Utils";
+import { ExponentialCost, FirstFreeCost, LinearCost } from "./api/Costs";
+import { Localization } from "./api/Localization";
+import { BigNumber, parseBigNumber } from "./api/BigNumber";
+import { theory } from "./api/Theory";
+import { Utils } from "./api/Utils";
 
 var id = "convergence_test"
 var name = "Convergence Test";


### PR DESCRIPTION
changes all the "../api/<function>" to "./api/<function>", significantly decreasing confusion when using code from any of the examples given.
also bumps the version of t4 to v2, as it is technically the second version of t4 