### PR TITLE
Add key handling to CommandLine

### DIFF
--- a/sdk/TheorySDK/Views/MainForm.xeto.cs
+++ b/sdk/TheorySDK/Views/MainForm.xeto.cs
@@ -203,9 +203,15 @@ namespace TheorySDK.Views
         private void OnCommandLineKeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyData == Keys.Up)
+            {
                 MoveHistory(-1);
+                e.Handled = true;
+            }
             else if (e.KeyData == Keys.Down)
+            {
                 MoveHistory(1);
+                e.Handled = true;
+            }
             else if (e.KeyData == Keys.Enter)
             {
                 if (_app.HasClient())
@@ -228,6 +234,7 @@ namespace TheorySDK.Views
                 {
                     _app.Logger.Log("Error: Cannot send command without client.");
                 }
+                e.Handled = true;
             }
         }
 


### PR DESCRIPTION
This PR prevents `CommandLine` from losing focus upon viewing history and prevents newlines from being inserted.